### PR TITLE
Backend Service networking patch

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,9 +63,11 @@ app.use((req, res) => {
 initDB()
     .then(result => {
         if (result.success) {
-            const appPort = envVar("APP_PORT");
-            app.listen(appPort, async () => {
-                console.log(`Server is listening on port ${appPort}`);
+           const appPort = envVar("APP_PORT") || process.env.PORT || 3000;
+           const appHost = process.env.HOST || envVar("HOST") || '0.0.0.0';
+           
+           app.listen(appPort, appHost, async () => {
+            console.log(`Server is listening on ${appHost}:${appPort}`);
             })
         }
         else {

--- a/app.js
+++ b/app.js
@@ -63,11 +63,11 @@ app.use((req, res) => {
 initDB()
     .then(result => {
         if (result.success) {
-           const appPort = envVar("APP_PORT") || process.env.PORT || 3000;
-           const appHost = process.env.HOST || envVar("HOST") || '0.0.0.0';
+            const appPort = envVar("APP_PORT") || process.env.PORT || 3000;
+            const appHost = process.env.HOST || envVar("HOST") || '0.0.0.0';
            
-           app.listen(appPort, appHost, async () => {
-            console.log(`Server is listening on ${appHost}:${appPort}`);
+            app.listen(appPort, appHost, async () => {
+                console.log(`Server is listening on ${appHost}:${appPort}`);
             })
         }
         else {


### PR DESCRIPTION
Allow backend service to listen on all interfaces on the host machine/VM.
This allows incoming IPV4 traffic together with IPV6.